### PR TITLE
Ignorepattern for LineLength checkstyle.

### DIFF
--- a/plugin/src/main/resources/checkstyle/conf-default.xml
+++ b/plugin/src/main/resources/checkstyle/conf-default.xml
@@ -48,6 +48,7 @@
         <module name="LeftCurly"/>
         <module name="LineLength">
             <property name="max" value="100"/>
+            <property name="ignorePattern" value="\/\/"/>
         </module>
         <module name="RightCurly"/>
         <module name="RightCurly">


### PR DESCRIPTION
This will ignore linelength on comments and todos.